### PR TITLE
Add nbextensions

### DIFF
--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,6 +1,12 @@
 panel build panel_chemistry
 pip install voila>=0.2.10 -U
 conda install -c conda-forge jupyter_contrib_nbextensions
+jupyter nbextension enable codefolding/main
+jupyter nbextension enable collapsible_headings/main
+jupyter nbextension enable comment-uncomment/main
+jupyter nbextension enable hide_input/main
+jupyter nbextension enable scratchpad/main
+jupyter nbextension enable init_cell/main
 conda install -c conda-forge code-server
 code-server --install-extension ms-python.python
 SERVICE_URL=https://open-vsx.org/vscode/gallery ITEM_URL=https://open-vsx.org/vscode/item code-server --install-extension wesbos.theme-cobalt2

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,5 +1,6 @@
 panel build panel_chemistry
 pip install voila>=0.2.10 -U
+conda install -c conda-forge jupyter_contrib_nbextensions
 conda install -c conda-forge code-server
 code-server --install-extension ms-python.python
 SERVICE_URL=https://open-vsx.org/vscode/gallery ITEM_URL=https://open-vsx.org/vscode/item code-server --install-extension wesbos.theme-cobalt2

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,6 +1,5 @@
 -e .['all']
 -e binder/jupyter-panel-apps-server/.
-jupyter_contrib_nbextensions
 holoviews
 hvplot
 colorcet

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,5 +1,6 @@
 -e .['all']
 -e binder/jupyter-panel-apps-server/.
+jupyter_contrib_nbextensions
 holoviews
 hvplot
 colorcet


### PR DESCRIPTION
For some reason binder opens jupyter classic rather than jupyter-lab.

Also, there are still libraries that work in classic, but not in lab.
I therefore added nb_extensions, and activated the extensions I personally find most useful.
(You might like section folding :-)