### PR TITLE
Add file input widget

### DIFF
--- a/examples/reference/NGLViewer.ipynb
+++ b/examples/reference/NGLViewer.ipynb
@@ -49,7 +49,7 @@
    "source": [
     "import panel as pn \n",
     "from panel_chemistry.pane import NGLViewer # panel_chemistry needs to be imported before you run pn.extension()\n",
-    "\n",
+    "from panel_chemistry.pane.ngl_viewer import EXTENSIONS\n",
     "pn.extension(\"ngl_viewer\", sizing_mode=\"stretch_width\")"
    ]
   },
@@ -76,6 +76,40 @@
     "    name=\"&#9881;&#65039; Settings\"\n",
     ")"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "outputs": [
+    {
+     "ename": "SyntaxError",
+     "evalue": "unmatched ')' (<ipython-input-2-f466f1b8b152>, line 13)",
+     "output_type": "error",
+     "traceback": [
+      "\u001B[1;36m  File \u001B[1;32m\"<ipython-input-2-f466f1b8b152>\"\u001B[1;36m, line \u001B[1;32m13\u001B[0m\n\u001B[1;33m    pn.widgets.StaticText(value='<b>{0}</b>'.format(name)))\u001B[0m\n\u001B[1;37m                                                          ^\u001B[0m\n\u001B[1;31mSyntaxError\u001B[0m\u001B[1;31m:\u001B[0m unmatched ')'\n"
+     ]
+    }
+   ],
+   "source": [
+    "file_input = pn.widgets.FileInput(accept=','.join('.' + s for s in EXTENSIONS[1:]))\n",
+    "\n",
+    "def filename_callback(target, event):\n",
+    "    target.extension = event.new.split('.')[1]\n",
+    "\n",
+    "def value_callback(target, event):\n",
+    "    target.object = event.new.decode('utf-8')\n",
+    "\n",
+    "file_input.link(viewer, callbacks={'value': value_callback, 'filename': filename_callback})\n",
+    "\n",
+    "header = pn.widgets.StaticText(value='<b>{0}</b>'.format(\"&#128190; File Input\"))\n",
+    "file_column = pn.layout.Column(header, file_input)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
   },
   {
    "cell_type": "code",
@@ -122,7 +156,7 @@
     "pn.template.FastListTemplate(\n",
     "    site=\"Panel Chemistry\", \n",
     "    title=\"NGLViewer\", \n",
-    "    sidebar=[settings, layout],\n",
+    "    sidebar=[file_column, settings, layout],\n",
     "    main=[viewer]\n",
     ").servable();"
    ]


### PR DESCRIPTION
When 'blob' input is used the string is often too long to be pasted into the 'Object' field. 
This PR adds a file input widgets which sets the 'objects' field from the file data as well as the 'extension' from the filename