### PR TITLE
Fixing issue #23 (import error with panel 0.13+)

### DIFF
--- a/panel_chemistry/pane/ngl_viewer.py
+++ b/panel_chemistry/pane/ngl_viewer.py
@@ -12,7 +12,8 @@ from typing import Dict
 import param
 from panel import extension
 from panel.pane.base import PaneBase
-from panel.util import lazy_load, string_types
+from panel.util import lazy_load
+from six import string_types
 from pyviz_comms import JupyterComm
 
 # pylint: disable=protected-access


### PR DESCRIPTION
Fixing issue in #23 : `cannot import name 'string_types' from 'panel.util'`
They removes  `from six import string_types` in panel 0.13, so I juste replaced 
```python 
from panel.util import lazy_load, string_types
``` 
by 
```python
from panel.util import lazy_load
from six import string_types
```